### PR TITLE
Bump WebSphere Liberty to version 8.5.5.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Based on wasdev/websphere-liberty & ubuntu
 ############################################################
 
-FROM websphere-liberty:8.5.5
+FROM websphere-liberty:8.5.5.9
 MAINTAINER Michael Boudreau <mkboudreau@yahoo.com>
 
 ### INSTALL CONFD


### PR DESCRIPTION
This supports stable Java 8 deployment in Liberty
